### PR TITLE
decrease liquidity event duration to 3 days

### DIFF
--- a/contracts/JusDeFi.sol
+++ b/contracts/JusDeFi.sol
@@ -35,7 +35,7 @@ contract JusDeFi is IJusDeFi, ERC20 {
   address public immutable _jdfiStakingPool;
   address public immutable _univ2StakingPool;
 
-  uint private constant LIQUIDITY_EVENT_PERIOD = 4 days;
+  uint private constant LIQUIDITY_EVENT_PERIOD = 3 days;
   bool public _liquidityEventOpen;
   uint public immutable _liquidityEventClosedAt;
 


### PR DESCRIPTION
@mudgen Due to the delay in launch, we have decided to decrease the liquidity event duration to three days.  This shouldn't interact with the other time-sensitive functions, because the `FeePool` is not deployed until the close of the liquidity event.  However, if you think reviewing this change will require substantially more time, we will keep the current duration of four days.